### PR TITLE
Fix compile error, add compile script and some improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,12 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 name = "basic_eth"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.9.11",
  "ethereum-tx-sign",
  "fastrand",
  "hex",
- "ic-cdk 0.6.10",
- "ic-cdk-macros",
+ "ic-cdk 0.11.3",
+ "ic-cdk-macros 0.6.10",
  "ic-cdk-timers",
  "ic-web3",
  "rlp",
@@ -190,7 +190,7 @@ dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive",
+ "candid_derive 0.5.0",
  "codespan-reporting",
  "crc32fast",
  "data-encoding",
@@ -201,12 +201,39 @@ dependencies = [
  "logos",
  "num-bigint",
  "num-traits",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
- "pretty",
+ "pretty 0.10.0",
  "serde",
  "serde_bytes",
  "sha2 0.10.7",
+ "thiserror",
+]
+
+[[package]]
+name = "candid"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465c1ce01d8089ee5b49ba20d3a9da15a28bba64c35cdff2aa256d37e319625d"
+dependencies = [
+ "anyhow",
+ "binread",
+ "byteorder",
+ "candid_derive 0.6.4",
+ "codespan-reporting",
+ "crc32fast",
+ "data-encoding",
+ "hex",
+ "leb128",
+ "num-bigint",
+ "num-traits",
+ "num_enum 0.6.1",
+ "paste",
+ "pretty 0.12.3",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.7",
+ "stacker",
  "thiserror",
 ]
 
@@ -220,6 +247,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "candid_derive"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201ea498d901add0822653ac94cb0f8a92f9b1758a5273f4dafbb6673c9a5020"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -646,27 +685,26 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.6.10"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98b304a2657bad15bcb547625a018e13cf596676d834cfd93023395a6e2e03a"
+checksum = "9beb0bf1dcd0639c313630e34aa547a2b19450ddf1969c176e13225ef3b29048"
 dependencies = [
- "candid",
- "cfg-if",
- "ic-cdk-macros",
- "ic0",
+ "candid 0.8.4",
+ "ic-cdk-macros 0.6.10",
+ "ic0 0.18.11",
  "serde",
  "serde_bytes",
 ]
 
 [[package]]
 name = "ic-cdk"
-version = "0.7.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9beb0bf1dcd0639c313630e34aa547a2b19450ddf1969c176e13225ef3b29048"
+checksum = "c126ac20219abff15c3441282e9da6aa7244319d5a4a42c7260667237e790712"
 dependencies = [
- "candid",
- "ic-cdk-macros",
- "ic0",
+ "candid 0.9.11",
+ "ic-cdk-macros 0.8.1",
+ "ic0 0.21.1",
  "serde",
  "serde_bytes",
 ]
@@ -677,7 +715,21 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf50458685a0fc6b0e414cdba487610aeb199ac94db52d9fd76270565debee7"
 dependencies = [
- "candid",
+ "candid 0.8.4",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6295fd7389c198a97dd99b28b846e18487d99303077102d817eebbf6a924cd"
+dependencies = [
+ "candid 0.9.11",
  "proc-macro2",
  "quote",
  "serde",
@@ -693,7 +745,7 @@ checksum = "c739e7c592cb66df4f15c6b6c4859b1195782f63923e2fb1b29553d9c0819bd4"
 dependencies = [
  "futures",
  "ic-cdk 0.7.4",
- "ic0",
+ "ic0 0.18.11",
  "serde",
  "serde_bytes",
  "slotmap",
@@ -705,7 +757,7 @@ version = "0.1.7"
 source = "git+https://github.com/dipanshuhappy/ic-web3#903223b7d606795178183825436b43c4cb23c764"
 dependencies = [
  "arrayvec 0.7.4",
- "candid",
+ "candid 0.8.4",
  "derive_more",
  "ethabi",
  "ethereum-types",
@@ -715,7 +767,7 @@ dependencies = [
  "getrandom",
  "hex",
  "ic-cdk 0.7.4",
- "ic-cdk-macros",
+ "ic-cdk-macros 0.6.10",
  "jsonrpc-core",
  "libsecp256k1",
  "parking_lot",
@@ -731,6 +783,12 @@ name = "ic0"
 version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
+
+[[package]]
+name = "ic0"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
 
 [[package]]
 name = "impl-codec"
@@ -1033,7 +1091,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -1046,6 +1113,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1189,6 +1268,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1532,6 +1631,19 @@ name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"

--- a/did.sh
+++ b/did.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+
+function generate_did() {
+  local canister=$1
+  canister_root="src/$canister"
+
+  cargo build --manifest-path="$canister_root/Cargo.toml" \
+      --target wasm32-unknown-unknown \
+      --release --package "$canister" \
+
+  candid-extractor "target/wasm32-unknown-unknown/release/$canister.wasm" > "$canister_root/$canister.did"
+}
+
+CANISTERS=basic_eth
+
+for canister in $(echo $CANISTERS | sed "s/,/ /g")
+do
+    generate_did "$canister"
+done

--- a/src/basic_eth/Cargo.toml
+++ b/src/basic_eth/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-candid = "0.8.2"
-ic-cdk = "0.6.0"
+candid = "0.9.9"
+ic-cdk = "0.11.1"
 serde = "1"
 hex = "0.4.3"
 ic-cdk-timers = "0.1.1"

--- a/src/basic_eth/basic_eth.did
+++ b/src/basic_eth/basic_eth.did
@@ -7,10 +7,10 @@ type HttpResponse = record {
 type Result = variant { Ok : text; Err : text };
 type TransformArgs = record { context : vec nat8; response : HttpResponse };
 service : {
-  get_eth_address : () -> (Result); 
+  eth_to_wei : (float64) -> (Result) query;
+  get_eth_address : () -> (Result);
   get_eth_balance : () -> (Result);
   get_eth_gas_price : () -> (Result);
-  send_eth_in_wei : (text, float64) -> (Result);
-  eth_to_wei : (float64) -> (text) query;
- 
+  send_eth_in_ether : (text, float64, opt nat64) -> (Result);
+  transform : (TransformArgs) -> (HttpResponse) query;
 }

--- a/src/basic_eth/src/lib.rs
+++ b/src/basic_eth/src/lib.rs
@@ -142,10 +142,10 @@ async fn send_eth_in_ether(to: String, eth_value: f64, nonce: Option<u64>) -> Re
         .map_err(|e| format!("sign tx error: {}", e))?;
     match w3.eth().send_raw_transaction(signed_tx.raw_transaction).await {
         Ok(txhash) => { 
-            ic_cdk::println!("txhash: {}", hex::encode(txhash.0));
-            Ok(format!("https://sepolia.etherscan.io/tx/{}", hex::encode(txhash.0)))
+            ic_cdk::println!("txhash: 0x{}", hex::encode(txhash.0));
+            Ok(format!("https://sepolia.etherscan.io/tx/0x{}", hex::encode(txhash.0)))
         },
-        Err(_e) => { Err(hex::encode(signed_tx.message_hash)) },
+        Err(e) => { Err(format!("Error:{}", e)) },
     }
     
 }


### PR DESCRIPTION
## Fixes and Improvements

1. I've noticed that the ic_cdk::export_candid!(); function was missing which would result in compiling issues when trying to update the .did file(the file was outdated leading to runtime errors when using the send_eth_in_wei function which doesn't exist)
2. Added a script called did.sh that can be used to generate the .did file and build the project
3. Removed unused imports to improve the maintainability and readability of the codebase
4. I have updated the URL variable to use a temporary Alchemy API key as yours wasn't working(I would suggest replacing this with your key)
5. I have noticed that the send_eth_in_ether would panic when using an invalid eth address for the **to** input due to using the insecure use of unwrap, so I've gone ahead and modified the logic to instead return an error if the **to** argument is not a valid eth address.
6. I have also added an input validation check for the eth_value to ensure that negative values or zero are not accepted as the f64 types allow negative input values
7. I have improved the error returned when the send_raw_trasaction function fails in the send_ether_in_ether function by returning an Err response with the error object returned from the send_raw_transaction function instead of using an Ok response to return the message hash as an Ok response should only be returned in successful cases. 
8. I have also added the "0x" prefix to the tx hash as the current hash returned in the println! method and the OK response wouldn't lead to the transaction details page of the transaction due to the incorrect format used.